### PR TITLE
added flag and capability to download dexmetadata

### DIFF
--- a/googleplay-protobuf/protos/GooglePlay.proto
+++ b/googleplay-protobuf/protos/GooglePlay.proto
@@ -23,6 +23,7 @@ message AndroidAppDeliveryData {
   optional int64 type = 17;
   optional CompressedAppData compressedAppData = 18;
   optional string sha256 = 19;
+  optional DexMetadata dexMetadata = 21
 }
 
 message SplitDeliveryData {
@@ -48,6 +49,12 @@ message AndroidAppPatchData {
 message CompressedAppData{
   optional int64 type = 1;
   optional int64 size = 2;
+  optional string downloadUrl = 3;
+}
+
+message DexMetadata {
+  optional int64 downloadSize = 1;
+  optional string sha256 = 2;
   optional string downloadUrl = 3;
 }
 

--- a/googleplay-protobuf/src/googleplay.rs
+++ b/googleplay-protobuf/src/googleplay.rs
@@ -40,6 +40,8 @@ pub struct AndroidAppDeliveryData {
     pub compressed_app_data: ::core::option::Option<CompressedAppData>,
     #[prost(string, optional, tag = "19")]
     pub sha256: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(message, optional, tag = "21")]
+    pub dex_metadata: ::core::option::Option<DexMetadata>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -84,6 +86,16 @@ pub struct CompressedAppData {
     pub r#type: ::core::option::Option<i64>,
     #[prost(int64, optional, tag = "2")]
     pub size: ::core::option::Option<i64>,
+    #[prost(string, optional, tag = "3")]
+    pub download_url: ::core::option::Option<::prost::alloc::string::String>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DexMetadata {
+    #[prost(int64, optional, tag = "1")]
+    pub download_size: ::core::option::Option<i64>,
+    #[prost(string, optional, tag = "2")]
+    pub sha256: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(string, optional, tag = "3")]
     pub download_url: ::core::option::Option<::prost::alloc::string::String>,
 }


### PR DESCRIPTION
`.dm` file contain cloud profiles used by Android
for ahead-of-time compilation during installation

We developed this patch and used it for our research paper on [Profile coverage](https://themoep.at/research/2025-profile-coverage.pdf), it also has more info on cloud profiles :)

I didn't include a version bump yet but since it changes the API for the `download()` method a major version bump might be necessary.