### PR TITLE
[gpapi] Add droidguard_results header in AuthRequest to get AAS token

### DIFF
--- a/gpapi/src/lib.rs
+++ b/gpapi/src/lib.rs
@@ -1030,6 +1030,10 @@ impl Default for AuthRequest {
             String::from("callerSig"),
             String::from(consts::defaults::DEFAULT_CALLER_SIG)
         );
+        params.insert(
+            String::from("droidguard_results"),
+            String::from("null")
+        );
         AuthRequest {
             params,
         }


### PR DESCRIPTION
# Goal

This header now seems to be needed during authentication request with the Google Play API to get the AAS token.

## Information

- This fix is from a similar issue and fix at AuroraStore: https://gitlab.com/AuroraOSS/AuroraStore/-/work_items/1475
- I have successfully tested this fix locally via `apkeep`
- Fix https://github.com/EFForg/apkeep/issues/231